### PR TITLE
Fix UTF-8 encoding of accented letter in titles

### DIFF
--- a/projects/eHealthSuisse/eMedikation/v1.0/1-1-MedicationTreatmentPlan.xml
+++ b/projects/eHealthSuisse/eMedikation/v1.0/1-1-MedicationTreatmentPlan.xml
@@ -152,7 +152,7 @@
 					<code code="77604-7" codeSystem="2.16.840.1.113883.6.1"
 						codeSystemName="LOINC" displayName="Medication treatment plan.brief" />
 
-					<title>Medikamentöser Behandlungsplan</title>
+					<title>Medikamentöser Behandlungsplan</title>
 
 					<text>
 						<table>

--- a/projects/eHealthSuisse/eMedikation/v1.0/2-3-MedicationTreatmentPlan.xml
+++ b/projects/eHealthSuisse/eMedikation/v1.0/2-3-MedicationTreatmentPlan.xml
@@ -154,7 +154,7 @@
 					<code code="77604-7" codeSystem="2.16.840.1.113883.6.1"
 						codeSystemName="LOINC" displayName="Medication treatment plan.brief" />
 
-					<title>Medikamentöser Behandlungsplan</title>
+					<title>Medikamentöser Behandlungsplan</title>
 
 					<text>
 						<table>

--- a/projects/eHealthSuisse/eMedikation/v1.0/2-5-MedicationTreatmentPlan.xml
+++ b/projects/eHealthSuisse/eMedikation/v1.0/2-5-MedicationTreatmentPlan.xml
@@ -154,7 +154,7 @@
 					<code code="77604-7" codeSystem="2.16.840.1.113883.6.1"
 						codeSystemName="LOINC" displayName="Medication treatment plan.brief" />
 
-					<title>Medikamentöser Behandlungsplan</title>
+					<title>Medikamentöser Behandlungsplan</title>
 
 					<text>
 						<table>


### PR DESCRIPTION
In the CDA-CH-EMED MTP example documents, the title 'Medikamentöser Behandlungsplan' contains a badly encoded 'ö'.
It is encoded as U+006F U+0308 (o  ̈ ) and should be encoded as U+00F6 (ö) according to the Schematron.

It passes now the validation ([example](https://ehealthsuisse.ihe-europe.net/EVSClient//detailedResult.seam?type=CDA&oid=1.3.6.1.4.1.12559.11.25.1.13.46076)).