### PR TITLE
Add FHIR and HL7 values to the TimingEvent value set

### DIFF
--- a/schemas/coreschemas/voc.xsd
+++ b/schemas/coreschemas/voc.xsd
@@ -10,7 +10,7 @@ History:
 2013.05.17 Tony Schaller, medshare GmbH, Switzerland (re-formatted cr/lf)
 2013.05.18 Tony Schaller, medshare GmbH, Switzerland (namespaces added)
 2018.07.08 Tony Schaller, medshare GmbH, Switzerland (ELGA extensions incorporated)
-
+2021.06.08 Quentin Ligier for eHealthSuisse (improved the TimingEvent value set)
 *******************************************************************************
 -->
 <xs:schema
@@ -588,14 +588,36 @@ History:
 			<xs:enumeration value="PCD"/>
 			<xs:enumeration value="PCM"/>
 			<xs:enumeration value="PCV"/>
-			<xs:enumeration value="CM"/>
-			<xs:enumeration value="CD"/>
-			<xs:enumeration value="CV"/>
 			<!--
 			ELGA extensions
 			added: CM, CD, CV
 			Author: ELGA GmbH, 2014
 			-->
+			<xs:enumeration value="CM"/>
+			<xs:enumeration value="CD"/>
+			<xs:enumeration value="CV"/>
+			<!-- 
+			Completion of the HL7 value set
+			Author: eHealthSuisse, 2021
+			-->
+			<xs:enumeration value="C"/>
+			<xs:enumeration value="WAKE"/>
+			<!-- 
+			Adding the FHIR value set
+			Author: eHealthSuisse, 2021
+			-->
+			<xs:enumeration value="MORN"/>
+			<xs:enumeration value="MORN.early"/>
+			<xs:enumeration value="MORN.late"/>
+			<xs:enumeration value="NOON"/>
+			<xs:enumeration value="AFT"/>
+			<xs:enumeration value="AFT.early"/>
+			<xs:enumeration value="AFT.late"/>
+			<xs:enumeration value="EVE"/>
+			<xs:enumeration value="EVE.early"/>
+			<xs:enumeration value="EVE.late"/>
+			<xs:enumeration value="NIGHT"/>
+			<xs:enumeration value="PHS"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="URLScheme">


### PR DESCRIPTION
The value C and WAKE from the HL7 value set were missing and have been added. All the values from the FHIR value set have been added.